### PR TITLE
String/wstring conversion fix, attempt #2.

### DIFF
--- a/include/Helpers/String.hpp
+++ b/include/Helpers/String.hpp
@@ -139,11 +139,6 @@ namespace RC
     }
     /* explode_by_occurrence -> END */
 
-    auto inline is_valid_ascii(char character) -> bool
-    {
-        return character >= 0 && static_cast<uint8_t>(character) <= 127;
-    }
-
     auto inline to_wstring(std::string& input) -> std::wstring
     {
 #pragma warning(disable: 4996)

--- a/include/Helpers/String.hpp
+++ b/include/Helpers/String.hpp
@@ -1,7 +1,8 @@
 #ifndef RC_STRING_HPP
 #define RC_STRING_HPP
 
-#include <cstdlib>
+#include <locale>
+#include <codecvt>
 #include <string>
 #include <cwctype>
 #include <vector>
@@ -138,38 +139,37 @@ namespace RC
     }
     /* explode_by_occurrence -> END */
 
+    auto inline is_valid_ascii(char character) -> bool
+    {
+        return character >= 0 && static_cast<uint8_t>(character) <= 127;
+    }
+
     auto inline to_wstring(std::string& input) -> std::wstring
     {
-#pragma warning(disable: 4244)
-        return std::wstring{input.begin(), input.end()};
-#pragma warning(default: 4244)
+#pragma warning(disable: 4996)
+        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter{};
+        return converter.from_bytes(input);
+#pragma warning(default: 4996)
     }
 
     auto inline to_wstring(std::string_view input) -> std::wstring
     {
-#pragma warning(disable: 4244)
-        return std::wstring{input.begin(), input.end()};
-#pragma warning(default: 4244)
+        auto temp_input = std::string{input};
+        return to_wstring(temp_input);
     }
 
     auto inline to_string(std::wstring& input) -> std::string
     {
-        if (input.empty()) { return {}; }
 #pragma warning(disable: 4996)
-        std::string ascii_str(input.length(), '!');
-        std::wcstombs(&ascii_str[0], input.c_str(), input.length());
-        return ascii_str;
+        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter{};
+        return converter.to_bytes(input);
 #pragma warning(default: 4996)
     }
 
     auto inline to_string(std::wstring_view input) -> std::string
     {
-        if (input.empty()) { return {}; }
-#pragma warning(disable: 4996)
-        std::string ascii_str(input.length(), '!');
-        std::wcstombs(&ascii_str[0], input.data(), input.length());
-        return ascii_str;
-#pragma warning(default: 4996)
+        auto temp_input = std::wstring{input};
+        return to_string(temp_input);
     }
 
     namespace String

--- a/include/Helpers/String.hpp
+++ b/include/Helpers/String.hpp
@@ -1,6 +1,7 @@
 #ifndef RC_STRING_HPP
 #define RC_STRING_HPP
 
+#include <cstdlib>
 #include <string>
 #include <cwctype>
 #include <vector>
@@ -153,16 +154,20 @@ namespace RC
 
     auto inline to_string(std::wstring& input) -> std::string
     {
-#pragma warning(disable: 4244)
-        return std::string{input.begin(), input.end()};
-#pragma warning(default: 4244)
+#pragma warning(disable: 4996)
+        std::string ascii_str(input.length(), '!');
+        std::wcstombs(&ascii_str[0], input.c_str(), input.length());
+        return ascii_str;
+#pragma warning(default: 4996)
     }
 
     auto inline to_string(std::wstring_view input) -> std::string
     {
-#pragma warning(disable: 4244)
-        return std::string{input.begin(), input.end()};
-#pragma warning(default: 4244)
+#pragma warning(disable: 4996)
+        std::string ascii_str(input.length(), '!');
+        std::wcstombs(&ascii_str[0], input.data(), input.length());
+        return ascii_str;
+#pragma warning(default: 4996)
     }
 
     namespace String
@@ -204,3 +209,4 @@ namespace RC
 }
 
 #endif //RC_STRING_HPP
+

--- a/include/Helpers/String.hpp
+++ b/include/Helpers/String.hpp
@@ -154,6 +154,7 @@ namespace RC
 
     auto inline to_string(std::wstring& input) -> std::string
     {
+        if (input.empty()) { return {}; }
 #pragma warning(disable: 4996)
         std::string ascii_str(input.length(), '!');
         std::wcstombs(&ascii_str[0], input.c_str(), input.length());
@@ -163,6 +164,7 @@ namespace RC
 
     auto inline to_string(std::wstring_view input) -> std::string
     {
+        if (input.empty()) { return {}; }
 #pragma warning(disable: 4996)
         std::string ascii_str(input.length(), '!');
         std::wcstombs(&ascii_str[0], input.data(), input.length());


### PR DESCRIPTION
In UE4SS, we now get the following results.

Regular console:
![FSD-Win64-Shipping_55Xrbx0iad](https://user-images.githubusercontent.com/118743303/205359861-f1055830-75bf-4918-9c36-7ca3e0af1626.png)

ImGui console:
![FSD-Win64-Shipping_oGb7vtkiKc](https://user-images.githubusercontent.com/118743303/205359876-a0d25d77-ff2d-49f5-b5d9-840d47090f4b.png)

The irregularity with the regular console is probably because it's set to a different character set on my computer.
Note also that as a result of this fix, the new-line is no longer cut off from lines being logged to console if the string contained non-ascii characters.